### PR TITLE
fix compilation with Xcode 12

### DIFF
--- a/Source/pinentry-0.9.4/pinentry/pinentry-curses.c
+++ b/Source/pinentry-0.9.4/pinentry/pinentry-curses.c
@@ -44,7 +44,7 @@
 #include <utime.h>
 #endif /*HAVE_UTIME_H*/
 
-#include <memory.h>
+#include "memory.h"
 
 #ifdef HAVE_WCHAR_H
 #include <wchar.h>


### PR DESCRIPTION
Calling functions with missing declarations is now an error by default. This bites me in `pinentry-curses.c`, which uses `secmem_free`, but does not include the local `memory.h` header. It includes the systemwide header instead, which I believe is not necessary. Changing the include statement fixes compilation with Xcode 12 (for macOS Big Sur).